### PR TITLE
Added 'measurement' state class to room temperature to be able to tra…

### DIFF
--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -543,6 +543,7 @@ SENSORS: list[descr] = [
         device_key=DeviceKey.heating,
         entity_category=None,
         icon="mdi:thermometer",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         visibility=LV.V0122_ROOM_THERMOSTAT,


### PR DESCRIPTION
…ck history

If state class is set to 'measurement', history can be tracked with recorder.

https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics